### PR TITLE
Removed dependencies from crazy ringbuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ repository = "https://github.com/sarum90/qjsonrs"
 readme = "README.md"
 
 [dependencies]
-libc = "0.2"
-rand = "0.6"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@
 #[cfg(test)] #[macro_use] extern crate matches;
 #[cfg(test)] #[macro_use] extern crate serde_json;
 #[cfg(test)]  extern crate os_pipe;
-extern crate libc;
-extern crate rand;
 
 mod decode;
 mod token;


### PR DESCRIPTION
Previous version had some crazy ringbuffer implemented. With that removed we no longer have a libc/rand dependency.