### PR TITLE
Prevent returning None / EOF when we haven't seen the EOF.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -415,6 +415,8 @@ impl JsonDecoder {
         let r = self.decode_impl(bytes);
         if let (Err(DecodeError::NeedsMore), true) = (&r, bytes.end_of_stream) {
             Err(DecodeError::UnexpectedEndOfStream)
+        } else if let (Ok(None), false) = (&r, bytes.end_of_stream) {
+            Err(DecodeError::NeedsMore)
         } else {
             r
         }


### PR DESCRIPTION
Specifically, when the buffer only has whitespace in it, we don't have a
token to return, but if the ConsumableBytes are not at the end of the
stream, then we must return NeedsMore, not None.