### PR TITLE
Cleanup branches after merge in merge script.

### DIFF
--- a/tools/merge.sh
+++ b/tools/merge.sh
@@ -41,6 +41,8 @@ PULL_URL=$(${CURL} https://api.github.com/repos/sarum90/qjsonrs/pulls \
 
 if [[ ${PULL_URL} == "" ]]; then
   error 'Could not find pull request based on this branch.'
+  echo
+  echo "Visit: https://github.com/sarum90/qjsonrs/pull/new/${BRANCH} to create one."
   exit -1
 fi
 

--- a/tools/merge.sh
+++ b/tools/merge.sh
@@ -29,9 +29,20 @@ if [[ $(git rev-parse HEAD) != $(git rev-parse @{u}) ]]; then
 fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ ${BRANCH} == "master" ]]; then
+  error 'Refusing to attempt to merge master into master.'
+  exit -1
+fi
+
+
 PULL_URL=$(${CURL} https://api.github.com/repos/sarum90/qjsonrs/pulls \
   | jq -r --arg branch "${BRANCH}" \
   '.[] | {url: .url, branch: .head.ref} | select(.branch == $branch) | .url')
+
+if [[ ${PULL_URL} == "" ]]; then
+  error 'Could not find pull request based on this branch.'
+  exit -1
+fi
 
 TMPDIR=$(mktemp -d)
 function finish {
@@ -110,3 +121,5 @@ git pull origin
 git merge --squash --no-commit  "${BRANCH}"
 git commit -F "${COMMIT_FILE}"
 git push origin
+git push origin ":${BRANCH}"
+git branch -D "${BRANCH}"


### PR DESCRIPTION
For ease of use, close delete the local branch and remote branch (which should close the PR), once a branch has been merged to master successfully.